### PR TITLE
Add lambda support to avoid having to register a listener for the event

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,2 +1,108 @@
 # Project exclude paths
 /target/
+
+### Eclipse ###
+.metadata
+bin/
+tmp/
+*.tmp
+*.bak
+*.swp
+*~.nib
+local.properties
+.settings/
+.loadpath
+.recommenders
+.classpath
+.project
+
+# External tool builders
+.externalToolBuilders/
+
+# Locally stored "Eclipse launch configurations"
+*.launch
+
+# PyDev specific (Python IDE for Eclipse)
+*.pydevproject
+
+# CDT-specific (C/C++ Development Tooling)
+.cproject
+
+# CDT- autotools
+.autotools
+
+# Java annotation processor (APT)
+.factorypath
+
+# PDT-specific (PHP Development Tools)
+.buildpath
+
+# sbteclipse plugin
+.target
+
+# Tern plugin
+.tern-project
+
+# TeXlipse plugin
+.texlipse
+
+# STS (Spring Tool Suite)
+.springBeans
+
+# Code Recommenders
+.recommenders/
+
+# Annotation Processing
+.apt_generated/
+.apt_generated_test/
+
+# Scala IDE specific (Scala & Java development for Eclipse)
+.cache-main
+.scala_dependencies
+.worksheet
+
+# Uncomment this line if you wish to ignore the project description file.
+# Typically, this file would be tracked if it contains build/dependency configurations:
+#.project
+
+### Eclipse Patch ###
+# Spring Boot Tooling
+.sts4-cache/
+
+### Java ###
+# Compiled class file
+*.class
+
+# Log file
+*.log
+
+# BlueJ files
+*.ctxt
+
+# Mobile Tools for Java (J2ME)
+.mtj.tmp/
+
+# Package Files #
+*.jar
+*.war
+*.nar
+*.ear
+*.zip
+*.tar.gz
+*.rar
+
+# virtual machine crash logs, see http://www.java.com/en/download/help/error_hotspot.xml
+hs_err_pid*
+
+### Maven ###
+target/
+pom.xml.tag
+pom.xml.releaseBackup
+pom.xml.versionsBackup
+pom.xml.next
+release.properties
+dependency-reduced-pom.xml
+buildNumber.properties
+.mvn/timing.properties
+# https://github.com/takari/maven-wrapper#usage-without-binary-jar
+.mvn/wrapper/maven-wrapper.jar

--- a/src/main/java/de/jeff_media/updatechecker/InternalUpdateCheckListener.java
+++ b/src/main/java/de/jeff_media/updatechecker/InternalUpdateCheckListener.java
@@ -17,18 +17,18 @@ class InternalUpdateCheckListener implements Listener {
     @EventHandler
     public void notifyOnJoin(PlayerJoinEvent playerJoinEvent) {
         Player player = playerJoinEvent.getPlayer();
-        if ((player.isOp() && instance.notifyOpsOnJoin) || (instance.notifyPermission != null && player.hasPermission(instance.notifyPermission))) {
-            Messages.printCheckResultToPlayer(player,false);
+        if ((player.isOp() && instance.isNotifyOpsOnJoin())|| (instance.getNotifyPermission() != null && player.hasPermission(instance.getNotifyPermission()))) {
+            Messages.printCheckResultToPlayer(player, false);
         }
     }
 
     @EventHandler
     public void onUpdateCheck(UpdateCheckEvent event) {
-        if (!instance.notifyRequesters) return;
+        if (!instance.isNotifyRequesters()) return;
         if (event.getRequesters() == null) return;
         for (CommandSender commandSender : event.getRequesters()) {
             if (commandSender instanceof Player) {
-                Messages.printCheckResultToPlayer((Player) commandSender,true);
+                Messages.printCheckResultToPlayer((Player) commandSender, true);
             } else {
                 Messages.printCheckResultToConsole(event);
             }

--- a/src/main/java/de/jeff_media/updatechecker/Messages.java
+++ b/src/main/java/de/jeff_media/updatechecker/Messages.java
@@ -1,23 +1,25 @@
 package de.jeff_media.updatechecker;
 
-import net.md_5.bungee.api.chat.ClickEvent;
-import net.md_5.bungee.api.chat.ComponentBuilder;
-import net.md_5.bungee.api.chat.HoverEvent;
-import net.md_5.bungee.api.chat.TextComponent;
+import java.util.ArrayList;
+import java.util.Iterator;
+import java.util.List;
+import java.util.logging.Level;
+import java.util.logging.Logger;
+import java.util.stream.Stream;
+
 import org.bukkit.ChatColor;
 import org.bukkit.entity.Player;
 import org.bukkit.plugin.Plugin;
 import org.jetbrains.annotations.NotNull;
 
-import java.util.ArrayList;
-import java.util.Iterator;
-import java.util.logging.Level;
-import java.util.logging.Logger;
-import java.util.stream.Stream;
+import net.md_5.bungee.api.chat.ClickEvent;
+import net.md_5.bungee.api.chat.ComponentBuilder;
+import net.md_5.bungee.api.chat.HoverEvent;
+import net.md_5.bungee.api.chat.TextComponent;
 
 class Messages {
 
-    @NotNull
+		@NotNull
     private static TextComponent createLink(@NotNull final String text, @NotNull final String link) {
         final ComponentBuilder lore = new ComponentBuilder("Link: ")
                 .bold(true)
@@ -48,13 +50,13 @@ class Messages {
             return;
         }
 
-        ArrayList<String> lines = new ArrayList<>();
+        List<String> lines = new ArrayList<>();
 
         lines.add(String.format("There is a new version of %s available!", plugin.getName()));
-        lines.add(String.format("  Your version: %s%s", instance.coloredConsoleOutput ? ChatColor.RED : "", event.getUsedVersion()));
-        lines.add(String.format("Latest version: %s%s", instance.coloredConsoleOutput ? ChatColor.GREEN : "", event.getLatestVersion()));
+        lines.add(String.format("  Your version: %s%s", instance.isColoredConsoleOutput() ? ChatColor.RED : "", event.getUsedVersion()));
+        lines.add(String.format("Latest version: %s%s", instance.isColoredConsoleOutput() ? ChatColor.GREEN : "", event.getLatestVersion()));
 
-        ArrayList<String> downloadLinks = instance.getAppropiateDownloadLinks();
+        List<String> downloadLinks = instance.getAppropiateDownloadLinks();
 
         if (downloadLinks.size() > 0) {
             lines.add(" ");
@@ -80,7 +82,7 @@ class Messages {
         if(instance.getLastCheckResult() == UpdateCheckResult.NEW_VERSION_AVAILABLE) {
             player.sendMessage(ChatColor.GRAY + "There is a new version of " + ChatColor.GOLD + instance.getPlugin().getName() + ChatColor.GRAY + " available.");
             sendLinks(player);
-            player.sendMessage(ChatColor.DARK_GRAY + "Latest version: " + ChatColor.GREEN + instance.cachedLatestVersion + ChatColor.DARK_GRAY + " | Your version: " + ChatColor.RED + instance.usedVersion);
+            player.sendMessage(ChatColor.DARK_GRAY + "Latest version: " + ChatColor.GREEN + instance.getCachedLatestVersion() + ChatColor.DARK_GRAY + " | Your version: " + ChatColor.RED + instance.getUsedVersion());
             player.sendMessage("");
         } else if(instance.getLastCheckResult() == UpdateCheckResult.UNKNOWN) {
             player.sendMessage(ChatColor.GOLD + instance.getPlugin().getName() + ChatColor.RED + " could not check for updates.");
@@ -91,7 +93,7 @@ class Messages {
         }
     }
 
-    private static void printNiceBoxToConsole(Logger logger, Level level, ArrayList<String> lines, int maxLineLengh, String dashSymbol, boolean prefix) {
+    private static void printNiceBoxToConsole(Logger logger, Level level, List<String> lines, int maxLineLengh, String dashSymbol, boolean prefix) {
         int longestLine = 0;
         for (String line : lines) {
             longestLine = Math.max(line.length(), longestLine);
@@ -100,7 +102,7 @@ class Messages {
         if (longestLine > maxLineLengh) longestLine = maxLineLengh;
         if (prefix) longestLine += 2;
         StringBuilder dash = new StringBuilder(longestLine);
-        Stream.generate(()->dashSymbol).limit(longestLine).forEach(dash::append);
+        Stream.generate(() -> dashSymbol).limit(longestLine).forEach(dash::append);
 
         logger.log(level, dash.toString());
         for (String line : lines) {
@@ -109,17 +111,17 @@ class Messages {
         logger.log(level, dash.toString());
     }
 
-    private static void sendLinks(@NotNull final Player player) {
+    private static void sendLinks(@NotNull final Player... players) {
 
         UpdateChecker instance = UpdateChecker.getInstance();
 
-        ArrayList<TextComponent> links = new ArrayList<>();
+        List<TextComponent> links = new ArrayList<>();
 
-        ArrayList<String> downloadLinks = instance.getAppropiateDownloadLinks();
+        List<String> downloadLinks = instance.getAppropiateDownloadLinks();
 
         if (downloadLinks.size() == 2) {
-            links.add(createLink(String.format("Download (%s)", instance.namePaidVersion), downloadLinks.get(0)));
-            links.add(createLink(String.format("Download (%s)", instance.nameFreeVersion), downloadLinks.get(1)));
+            links.add(createLink(String.format("Download (%s)", instance.getNamePaidVersion()), downloadLinks.get(0)));
+            links.add(createLink(String.format("Download (%s)", instance.getNameFreeVersion()), downloadLinks.get(1)));
         } else if (downloadLinks.size() == 1) {
             links.add(createLink("Download", downloadLinks.get(0)));
         }
@@ -144,6 +146,9 @@ class Messages {
             }
         }
 
-        player.spigot().sendMessage(text);
+        // MrNemo64 start
+        for(Player player : players)
+        	player.spigot().sendMessage(text);
+       // MrNemo64 end
     }
 }

--- a/src/main/java/de/jeff_media/updatechecker/UpdateCheckEvent.java
+++ b/src/main/java/de/jeff_media/updatechecker/UpdateCheckEvent.java
@@ -20,10 +20,10 @@ public class UpdateCheckEvent extends Event {
     protected UpdateCheckEvent(UpdateCheckSuccess success) {
         instance = UpdateChecker.getInstance();
         this.success = success;
-        if (success == UpdateCheckSuccess.FAIL && instance.cachedLatestVersion == null) {
+        if (success == UpdateCheckSuccess.FAIL && instance.getCachedLatestVersion() == null) {
             result = UpdateCheckResult.UNKNOWN;
         } else {
-            if (instance.usedVersion.equals(instance.cachedLatestVersion)) {
+            if (instance.isUsingLastestVersion()) {
                 result = UpdateCheckResult.RUNNING_LATEST_VERSION;
             } else {
                 result = UpdateCheckResult.NEW_VERSION_AVAILABLE;
@@ -46,7 +46,7 @@ public class UpdateCheckEvent extends Event {
      * @return
      */
     public @Nullable String getLatestVersion() {
-        return instance.cachedLatestVersion;
+        return instance.getCachedLatestVersion();
     }
 
     /**
@@ -88,7 +88,7 @@ public class UpdateCheckEvent extends Event {
      * @return
      */
     public @NotNull String getUsedVersion() {
-        return instance.usedVersion;
+        return instance.getUsedVersion();
     }
 
 }

--- a/src/main/java/de/jeff_media/updatechecker/UpdateCheckResult.java
+++ b/src/main/java/de/jeff_media/updatechecker/UpdateCheckResult.java
@@ -4,5 +4,7 @@ package de.jeff_media.updatechecker;
  * Represents whether a new version is available or not
  */
 public enum UpdateCheckResult {
-    NEW_VERSION_AVAILABLE, RUNNING_LATEST_VERSION, UNKNOWN
+    NEW_VERSION_AVAILABLE,
+    RUNNING_LATEST_VERSION,
+    UNKNOWN;
 }

--- a/src/main/java/de/jeff_media/updatechecker/UpdateCheckSuccess.java
+++ b/src/main/java/de/jeff_media/updatechecker/UpdateCheckSuccess.java
@@ -4,5 +4,6 @@ package de.jeff_media.updatechecker;
  * Represents whether the update check was successful
  */
 public enum UpdateCheckSuccess {
-    SUCCESS, FAIL
+    SUCCESS,
+    FAIL;
 }

--- a/src/main/java/de/jeff_media/updatechecker/UpdateChecker.java
+++ b/src/main/java/de/jeff_media/updatechecker/UpdateChecker.java
@@ -8,7 +8,6 @@ import java.util.ArrayList;
 import java.util.List;
 import java.util.Objects;
 import java.util.function.BiConsumer;
-import java.util.function.Consumer;
 
 import org.bukkit.Bukkit;
 import org.bukkit.command.CommandSender;
@@ -29,7 +28,7 @@ public class UpdateChecker {
 	private static boolean listenerAlreadyRegistered = false;
 	// MrNemo64 start
 	private BiConsumer<CommandSender[], String> onSuccessfulCachedLatestVersion = (requesters, cachedVersion) -> {};
-	private Consumer<Exception> onUnsuccessfulCachedLatestVersion = (ex) -> ex.printStackTrace();
+	private BiConsumer<CommandSender[],Exception> onUnsuccessfulCachedLatestVersion = (requesters, ex) -> ex.printStackTrace();
 	// MrNemo64 end
 	private String cachedLatestVersion = null;
 	private String nameFreeVersion = "Free";
@@ -193,7 +192,7 @@ public class UpdateChecker {
 				updateCheckEvent = new UpdateCheckEvent(UpdateCheckSuccess.SUCCESS);
 			} catch(final Exception e) {
 				updateCheckEvent = new UpdateCheckEvent(UpdateCheckSuccess.FAIL);
-				Bukkit.getScheduler().runTask(main, () -> getOnUnsuccessfulCachedLatestVersion().accept(e));
+				Bukkit.getScheduler().runTask(main, () -> getOnUnsuccessfulCachedLatestVersion().accept(requesters, e));
 			}
 
 			UpdateCheckEvent finalUpdateCheckEvent = updateCheckEvent.setRequesters(requesters);
@@ -631,7 +630,7 @@ public class UpdateChecker {
 	/**
 	 * @return the onUnsuccessfulCachedLatestVersion
 	 */
-	public Consumer<Exception> getOnUnsuccessfulCachedLatestVersion() {
+	public BiConsumer<CommandSender[], Exception> getOnUnsuccessfulCachedLatestVersion() {
 		return onUnsuccessfulCachedLatestVersion;
 	}
 
@@ -641,8 +640,8 @@ public class UpdateChecker {
 	 *                                          thrown in the version getting
 	 *                                          process
 	 */
-	public UpdateChecker setOnUnsuccessfulCachedLatestVersion(Consumer<Exception> onUnsuccessfulCachedLatestVersion) {
-		this.onUnsuccessfulCachedLatestVersion = onUnsuccessfulCachedLatestVersion == null ? (ex) -> ex.printStackTrace()
+	public UpdateChecker setOnUnsuccessfulCachedLatestVersion(BiConsumer<CommandSender[], Exception> onUnsuccessfulCachedLatestVersion) {
+		this.onUnsuccessfulCachedLatestVersion = onUnsuccessfulCachedLatestVersion == null ? (requesters, ex) -> ex.printStackTrace()
 				: onUnsuccessfulCachedLatestVersion;
 		return this;
 	}

--- a/src/main/java/de/jeff_media/updatechecker/UpdateChecker.java
+++ b/src/main/java/de/jeff_media/updatechecker/UpdateChecker.java
@@ -1,14 +1,14 @@
 package de.jeff_media.updatechecker;
 
 import java.io.BufferedReader;
-import java.io.IOException;
 import java.io.InputStreamReader;
 import java.net.HttpURLConnection;
-import java.net.MalformedURLException;
 import java.net.URL;
 import java.util.ArrayList;
 import java.util.List;
 import java.util.Objects;
+import java.util.function.BiConsumer;
+import java.util.function.Consumer;
 
 import org.bukkit.Bukkit;
 import org.bukkit.command.CommandSender;
@@ -21,540 +21,632 @@ import org.jetbrains.annotations.Nullable;
  */
 public class UpdateChecker {
 
-    protected static final String VERSION = "1.0.0";
-    private static final String SPIGOT_CHANGELOG_SUFFIX = "/history";
-    private static final String SPIGOT_DOWNLOAD_LINK = "https://www.spigotmc.org/resources/";
-    private static final String SPIGOT_UPDATE_API = "https://api.spigotmc.org/legacy/update.php?resource=";
-    private static UpdateChecker instance = null;
-    private static boolean listenerAlreadyRegistered = false;
-    private String cachedLatestVersion = null;
-    private String nameFreeVersion = "Free";
-    private String namePaidVersion = "Paid";
-    private String notifyPermission = null;
-    @SuppressWarnings("CanBeFinal")
-    private String spigotUserId = "%%__USER__%%";
-    private String usedVersion = null;
-    private String apiLink = null;
-    private String changelogLink = null;
-    private String donationLink = null;
-    private String freeDownloadLink = null;
-    private String paidDownloadLink = null;
-    private String userAgentString = null;
-    private boolean coloredConsoleOutput = false;
-    private boolean notifyOpsOnJoin = true;
-    private boolean notifyRequesters = true;
-    private boolean usingPaidVersion = false;
-    private Plugin main = null;
-    private int taskId = -1;
-    private int timeout = 0;
-    
-    /**
-     * Use UpdateChecker.init() instead. You can later get the instance by using UpdateChecker.getInstance()
-     */
-    private UpdateChecker() {
+	protected static final String VERSION = "1.0.0";
+	private static final String SPIGOT_CHANGELOG_SUFFIX = "/history";
+	private static final String SPIGOT_DOWNLOAD_LINK = "https://www.spigotmc.org/resources/";
+	private static final String SPIGOT_UPDATE_API = "https://api.spigotmc.org/legacy/update.php?resource=";
+	private static UpdateChecker instance = null;
+	private static boolean listenerAlreadyRegistered = false;
+	// MrNemo64 start
+	private BiConsumer<CommandSender[], String> onSuccessfulCachedLatestVersion = (requesters, cachedVersion) -> {};
+	private Consumer<Exception> onUnsuccessfulCachedLatestVersion = (ex) -> ex.printStackTrace();
+	// MrNemo64 end
+	private String cachedLatestVersion = null;
+	private String nameFreeVersion = "Free";
+	private String namePaidVersion = "Paid";
+	private String notifyPermission = null;
+	@SuppressWarnings("CanBeFinal")
+	private String spigotUserId = "%%__USER__%%";
+	private String usedVersion = null;
+	private String apiLink = null;
+	private String changelogLink = null;
+	private String donationLink = null;
+	private String freeDownloadLink = null;
+	private String paidDownloadLink = null;
+	private String userAgentString = null;
+	private boolean coloredConsoleOutput = false;
+	private boolean notifyOpsOnJoin = true;
+	private boolean notifyRequesters = true;
+	private boolean usingPaidVersion = false;
+	private Plugin main = null;
+	private int taskId = -1;
+	private int timeout = 0;
 
-    }
+	/**
+	 * Use UpdateChecker.init() instead. You can later get the instance by using
+	 * UpdateChecker.getInstance()
+	 */
+	private UpdateChecker() {
 
-    /**
-     * Gets the UpdateChecker instance
-     */
-    public static UpdateChecker getInstance() {
-        if (instance == null) {
-            instance = new UpdateChecker();
-        }
-        return instance;
-    }
+	}
 
-    /**
-     * Initializes the UpdateChecker instance. HAS to be called before the UpdateChecker can run.
-     *
-     * @param plugin           Main class of your plugin
-     * @param spigotResourceId SpigotMC Resource ID to get the latest version String from the SpigotMC Web API
-     * @return The UpdateChecker instance
-     */
-    public static UpdateChecker init(@NotNull Plugin plugin, int spigotResourceId) {
-        return init(plugin, SPIGOT_UPDATE_API + spigotResourceId);
-    }
+	/**
+	 * Gets the UpdateChecker instance
+	 */
+	public static UpdateChecker getInstance() {
+		if (instance == null) {
+			instance = new UpdateChecker();
+		}
+		return instance;
+	}
 
-    /**
-     * Initializes the UpdateChecker instance. HAS to be called before the UpdateChecker can run.
-     *
-     * @param plugin  Main class of your plugin
-     * @param apiLink HTTP(S) link to a file containing a string with the latest version of your plugin.
-     * @return The UpdateChecker instance
-     */
-    public static UpdateChecker init(@NotNull Plugin plugin, @NotNull String apiLink) {
-        Objects.requireNonNull(plugin, "Plugin cannot be null.");
-        Objects.requireNonNull(apiLink, "API Link cannot be null.");
+	/**
+	 * Initializes the UpdateChecker instance. HAS to be called before the
+	 * UpdateChecker can run.
+	 *
+	 * @param plugin           Main class of your plugin
+	 * @param spigotResourceId SpigotMC Resource ID to get the latest version String
+	 *                         from the SpigotMC Web API
+	 * @return The UpdateChecker instance
+	 */
+	public static UpdateChecker init(@NotNull Plugin plugin, int spigotResourceId) {
+		return init(plugin, SPIGOT_UPDATE_API + spigotResourceId);
+	}
 
-        UpdateChecker instance = getInstance();
+	/**
+	 * Initializes the UpdateChecker instance. HAS to be called before the
+	 * UpdateChecker can run.
+	 *
+	 * @param plugin  Main class of your plugin
+	 * @param apiLink HTTP(S) link to a file containing a string with the latest
+	 *                version of your plugin.
+	 * @return The UpdateChecker instance
+	 */
+	public static UpdateChecker init(@NotNull Plugin plugin, @NotNull String apiLink) {
+		Objects.requireNonNull(plugin, "Plugin cannot be null.");
+		Objects.requireNonNull(apiLink, "API Link cannot be null.");
 
-        instance.main = plugin;
-        instance.usedVersion = plugin.getDescription().getVersion().trim();
-        instance.apiLink = apiLink;
+		UpdateChecker instance = getInstance();
 
-        if (instance.detectPaidVersion()) instance.usingPaidVersion = true;
+		instance.main = plugin;
+		instance.usedVersion = plugin.getDescription().getVersion().trim();
+		instance.apiLink = apiLink;
 
-        if (!listenerAlreadyRegistered) {
-            Bukkit.getPluginManager().registerEvents(new InternalUpdateCheckListener(), plugin);
-            listenerAlreadyRegistered = true;
-        }
+		if (instance.detectPaidVersion())
+			instance.usingPaidVersion = true;
 
-        return instance;
-    }
-
-    /**
-     * Starts to check every X hours for updates - If a task is already running, it gets cancelled and replaced with the new one, so don't be afraid to use this in your reload function. The first check will also happen after X hours so you might want to call checkNow() too. When you set notifyRequesters to true (default), the Console will get a notification about the check result.
-     *
-     * @param hours Amount of hours in between checks
-     * @return The UpdateChecker instance
-     */
-    public UpdateChecker checkEveryXHours(double hours) {
-        double minutes = hours * 60;
-        double seconds = minutes * 60;
-        long ticks = ((int) seconds) * 20;
-        stop();
-        if (ticks > 0) {
-            taskId = Bukkit.getScheduler().scheduleSyncRepeatingTask(main, () -> checkNow(Bukkit.getConsoleSender()), ticks, ticks);
-        } else {
-            taskId = -1;
-        }
-        return this;
-    }
-
-    /**
-     * Checks for updates now and sends the result to the console when notifyRequesters is set to true (default)
-     */
-    public void checkNow() {
-        checkNow(Bukkit.getConsoleSender());
-    }
-
-    /**
-     * Returns the last successful Check Result
-     * @return 
-     */
-    public UpdateCheckResult getLastCheckResult() {
-        if(cachedLatestVersion == null) return UpdateCheckResult.UNKNOWN;
-        if(cachedLatestVersion.equals(usedVersion)) return UpdateCheckResult.RUNNING_LATEST_VERSION;
-        return UpdateCheckResult.NEW_VERSION_AVAILABLE;
-    }
-
-    /**
-     * Checks for updates now and sends the result to the given list of CommandSenders. Can be null to silently check for updates.
-     *
-     * @param requesters CommandSenders to send the result to, or null
-     */
-    public void checkNow(@Nullable CommandSender... requesters) {
-        if (main == null) {
-            throw new IllegalStateException("Plugin has not been set.");
-        }
-        if (apiLink == null) {
-            throw new IllegalStateException("API Link has not been set.");
-        }
-
-        if (userAgentString == null) {
-            userAgentString = UserAgentBuilder.getDefaultUserAgent().build();
-        }
-
-        Bukkit.getScheduler().runTaskAsynchronously(main, () -> {
-
-            UpdateCheckEvent updateCheckEvent;
-
-            try {
-                final HttpURLConnection httpConnection = (HttpURLConnection) new URL(apiLink).openConnection();
-                httpConnection.addRequestProperty("User-Agent", userAgentString);
-                if (timeout > 0) {
-                    httpConnection.setConnectTimeout(timeout);
-                }
-                final InputStreamReader input = new InputStreamReader(httpConnection.getInputStream());
-                final BufferedReader reader = new BufferedReader(input);
-                cachedLatestVersion = reader.readLine().trim();
-                reader.close();
-                updateCheckEvent = new UpdateCheckEvent(UpdateCheckSuccess.SUCCESS);
-            } catch (final MalformedURLException urlException) {
-                urlException.printStackTrace();
-                updateCheckEvent = new UpdateCheckEvent(UpdateCheckSuccess.FAIL);
-            } catch (final IOException ioException) {
-                updateCheckEvent = new UpdateCheckEvent(UpdateCheckSuccess.FAIL);
-            }
-
-            UpdateCheckEvent finalUpdateCheckEvent = updateCheckEvent.setRequesters(requesters);
-            Bukkit.getScheduler().runTask(main, () -> Bukkit.getPluginManager().callEvent(finalUpdateCheckEvent));
-        });
-    }
-
-    /**
-     * Checks that the class was properly relocated. Proudly stolen from bStats.org
-     */
-    private void checkRelocation() {
-        final String defaultPackage =
-                new String(new byte[] {'d', 'e', '.', 'j', 'e', 'f', 'f', '_', 'm', 'e', 'd', 'i', 'a', '.',
-                        'u', 'p', 'd', 'a', 't', 'e', 'c', 'h', 'e', 'c', 'k', 'e', 'r'});
-        final String examplePackage =
-                new String(new byte[] {'y', 'o', 'u', 'r', '.', 'p', 'a', 'c', 'k', 'a', 'g', 'e'});
-        if (this.getClass().getPackage().getName().startsWith(defaultPackage)
-                || this.getClass().getPackage().getName().startsWith(examplePackage)) {
-            throw new IllegalStateException("UpdateChecker class has not been relocated correctly!");
-        }
-    }
-
-    private boolean detectPaidVersion() {
-        return spigotUserId.matches("^[0-9]+$");
-    }
-
-    /**
-     * Returns a list of applicable Download links.
-     * <p>
-     * If using the free version and there are links for the free and paid version, element 0 will be the link to the paid version and element will be the link to the free version
-     * <p>
-     * If using the paid version, there will be only one element containing the link to the paid version, or, if that is not set, the link to the free version.
-     * <p>
-     * If there is no paid version, there will be only one element containing the link to the free version, or, if that is not set, the link to the plus version.
-     * <p>
-     * If no download links are set, returns an empty list.
-     *
-     * @return List of zero to two download links. If the list contains two links, the first element is the paid download link.
-     */
-    public List<String> getAppropiateDownloadLinks() {
-        List<String> list = new ArrayList<>();
-
-        if (usingPaidVersion) {
-            if (paidDownloadLink != null) {
-                list.add(paidDownloadLink);
-            } else if (freeDownloadLink != null) {
-                list.add(freeDownloadLink);
-            }
-        } else {
-            if (paidDownloadLink != null) {
-                list.add(paidDownloadLink);
-            }
-            if (freeDownloadLink != null) {
-                list.add(freeDownloadLink);
-            }
-        }
-        return list;
-    }
-
-    /**
-     * Returns the latest version string found by the UpdateChecker, or null if all checks until yet have failed.
-     *
-     * @return
-     */
-    public String getCachedLatestVersion() {
-        return cachedLatestVersion;
-    }
-
-    /**
-     * Returns the changelog link
-     *
-     * @return
-     */
-    public String getChangelogLink() {
-        return changelogLink;
-    }
-
-    /**
-     * Sets a link to your plugin's changelog generated from your plugin's SpigotMC Resource ID
-     *
-     * @param spigotResourceId
-     * @return
-     */
-    public UpdateChecker setChangelogLink(int spigotResourceId) {
-        return setChangelogLink(SPIGOT_DOWNLOAD_LINK + spigotResourceId + SPIGOT_CHANGELOG_SUFFIX);
-    }
-
-    /**
-     * Sets a link to your plugin's changelog.
-     *
-     * @param link
-     * @return
-     */
-    public UpdateChecker setChangelogLink(@Nullable String link) {
-        changelogLink = link;
-        return this;
-    }
-
-    /**
-     * Returns the donation link
-     *
-     * @return
-     */
-    public String getDonationLink() {
-        return donationLink;
-    }
-
-    /**
-     * Sets a link to your plugin's donation website
-     *
-     * @param donationLink
-     * @return
-     */
-    public UpdateChecker setDonationLink(@Nullable String donationLink) {
-        this.donationLink = donationLink;
-        return this;
-    }
-
-    protected Plugin getPlugin() {
-        return main;
-    }
-
-    /**
-     * Gets the version string of the currently used plugin version.
-     *
-     * @return
-     */
-    public String getUsedVersion() {
-        return usedVersion;
-    }
-
-    /**
-     * Sets whether or not the used and latest version will be displayed in color in the console
-     *
-     * @param coloredConsoleOutput
-     * @return
-     */
-    public UpdateChecker setColoredConsoleOutput(boolean coloredConsoleOutput) {
-        this.coloredConsoleOutput = coloredConsoleOutput;
-        return this;
-    }
-
-    /**
-     * Sets the download link for your plugin generated from your plugin's SpigotMC Resource ID. Use this if there is only one version of your plugin, either only a free or only a paid version.
-     *
-     * @param spigotResourceId
-     * @return
-     */
-    public UpdateChecker setDownloadLink(int spigotResourceId) {
-        return setDownloadLink(SPIGOT_DOWNLOAD_LINK + spigotResourceId);
-    }
-
-    /**
-     * Sets the download link for your plugin. Use this if there is only one version of your plugin, either only a free or only a paid version.
-     *
-     * @param downloadLink
-     * @return
-     */
-    public UpdateChecker setDownloadLink(@Nullable String downloadLink) {
-        this.paidDownloadLink = null;
-        this.freeDownloadLink = downloadLink;
-        return this;
-    }
-
-    /**
-     * Sets the download link for the free version of your plugin generated from your plugin's SpigotMC Resource ID. Use this if there is both, a free and a paid version of your plugin available.
-     *
-     * @param spigotResourceId
-     * @return
-     */
-    public UpdateChecker setFreeDownloadLink(int spigotResourceId) {
-        return setFreeDownloadLink(SPIGOT_DOWNLOAD_LINK + spigotResourceId);
-    }
-
-    /**
-     * Sets the download link for the free version of your plugin. Use this if there is both, a free and a paid version of your plugin available.
-     *
-     * @param freeDownloadLink
-     * @return
-     */
-    public UpdateChecker setFreeDownloadLink(@Nullable String freeDownloadLink) {
-        this.freeDownloadLink = freeDownloadLink;
-        return this;
-    }
-
-    /**
-     * Sets the suffix for the free version's name. E.g. when you set this to "Free", the Download link for the free version will be shown as "Download (Free): [Link]"
-     *
-     * @param nameFreeVersion
-     * @return
-     */
-    public UpdateChecker setNameFreeVersion(String nameFreeVersion) {
-        this.nameFreeVersion = nameFreeVersion;
-        return this;
-    }
-
-    /**
-     * Sets the suffix for the paid version's name. E.g. when you set this to "Platinum version", the Download link for the paid version will be shown as "Download (Platinum version): [Link]"
-     *
-     * @param namePaidVersion
-     * @return
-     */
-    public UpdateChecker setNamePaidVersion(String namePaidVersion) {
-        this.namePaidVersion = namePaidVersion;
-        return this;
-    }
-
-    /**
-     * You can set a permission name. Players joining with this permission will be informed when there is a new version available.
-     *
-     * @param permission
-     * @return
-     */
-    public UpdateChecker setNotifyByPermissionOnJoin(@Nullable String permission) {
-        notifyPermission = permission;
-        return this;
-    }
-
-    /**
-     * Whether or not to inform OPs on join when there is a new version available.
-     *
-     * @param notifyOpsOnJoin
-     * @return
-     */
-    public UpdateChecker setNotifyOpsOnJoin(boolean notifyOpsOnJoin) {
-        this.notifyOpsOnJoin = notifyOpsOnJoin;
-        return this;
-    }
-
-    /**
-     * Whether or not CommandSenders who request an update check will be notified of the result.
-     *
-     * @param notify
-     * @return
-     */
-    public UpdateChecker setNotifyRequesters(boolean notify) {
-        notifyRequesters = notify;
-        return this;
-    }
-
-    /**
-     * Sets the download link for the paid version of your plugin generated from your plugin's SpigotMC Resource ID. Use this if there is both, a free and a paid version of your plugin available.
-     *
-     * @param spigotResourceId
-     * @return
-     */
-    public UpdateChecker setPaidDownloadLink(int spigotResourceId) {
-        return setPaidDownloadLink(SPIGOT_DOWNLOAD_LINK + spigotResourceId);
-    }
-
-    /**
-     * Sets the download link for the paid version of your plugin. Use this if there is both, a free and a paid version of your plugin available.
-     *
-     * @param link
-     * @return
-     */
-    public UpdateChecker setPaidDownloadLink(@NotNull String link) {
-        paidDownloadLink = link;
-        return this;
-    }
-
-    /**
-     * Sets the timeout for the HTTP(S) connection in milliseconds. 0 = use Java's default value
-     *
-     * @param timeout
-     */
-    public UpdateChecker setTimeout(int timeout) {
-        this.timeout = timeout;
-        return this;
-    }
-
-    /**
-     * Sets the UserAgent string using a UserAgentBuilder
-     *
-     * @param userAgentBuilder
-     * @return
-     */
-    public UpdateChecker setUserAgent(@NotNull UserAgentBuilder userAgentBuilder) {
-        userAgentString = userAgentBuilder.build();
-        return this;
-    }
-
-    /**
-     * Sets the UserAgent string using plain text
-     *
-     * @param userAgent
-     * @return
-     */
-    public UpdateChecker setUserAgent(@Nullable String userAgent) {
-        userAgentString = userAgent;
-        return this;
-    }
-
-    /**
-     * Tells the UpdateChecker whether the server already uses the paid version of your plugin. If yes, the downloads to the free version are not shown. You can ignore this if you only offer one version of your plugin. When this value is not set, the Update Checker automatically sets this to true by checking the %%__USER__%% placeholder, see https://www.spigotmc.org/wiki/premium-resource-placeholders-identifiers/
-     *
-     * @param paidVersion
-     * @return
-     */
-    public UpdateChecker setUsingPaidVersion(boolean paidVersion) {
-        usingPaidVersion = paidVersion;
-        return this;
-    }
-
-    /**
-     * Stops the scheduled update checks - THIS IS NOT NEEDED when calling checkEveryXHours(double) again, as the UpdateChecker will automatically stop its previous task.
-     */
-    public void stop() {
-        if (taskId != -1) {
-            Bukkit.getScheduler().cancelTask(taskId);
-        }
-        taskId = -1;
-    }
-    
-    // MrNemo64 start
-    /**
-     * @return True if the lastest version si being used, false otherwise
-     */
-    public boolean isUsingLastestVersion() {
-    	return usedVersion.equals(instance.cachedLatestVersion);
-    }
-
-		/**
-		 * @return the nameFreeVersion
-		 */
-		public String getNameFreeVersion() {
-			return nameFreeVersion;
+		if (!listenerAlreadyRegistered) {
+			Bukkit.getPluginManager().registerEvents(new InternalUpdateCheckListener(), plugin);
+			listenerAlreadyRegistered = true;
 		}
 
-		/**
-		 * @return the namePaidVersion
-		 */
-		public String getNamePaidVersion() {
-			return namePaidVersion;
+		return instance;
+	}
+
+	/**
+	 * Starts to check every X hours for updates - If a task is already running, it
+	 * gets cancelled and replaced with the new one, so don't be afraid to use this
+	 * in your reload function. The first check will also happen after X hours so
+	 * you might want to call checkNow() too. When you set notifyRequesters to true
+	 * (default), the Console will get a notification about the check result.
+	 *
+	 * @param hours Amount of hours in between checks
+	 * @return The UpdateChecker instance
+	 */
+	public UpdateChecker checkEveryXHours(double hours) {
+		double minutes = hours * 60;
+		double seconds = minutes * 60;
+		long ticks = ((int) seconds) * 20;
+		stop();
+		if (ticks > 0) {
+			taskId = Bukkit.getScheduler().scheduleSyncRepeatingTask(main, () -> checkNow(Bukkit.getConsoleSender()), ticks,
+					ticks);
+		} else {
+			taskId = -1;
+		}
+		return this;
+	}
+
+	/**
+	 * Checks for updates now and sends the result to the console when
+	 * notifyRequesters is set to true (default)
+	 */
+	public void checkNow() {
+		checkNow(Bukkit.getConsoleSender());
+	}
+
+	/**
+	 * Returns the last successful Check Result
+	 * 
+	 * @return
+	 */
+	public UpdateCheckResult getLastCheckResult() {
+		if (cachedLatestVersion == null)
+			return UpdateCheckResult.UNKNOWN;
+		if (cachedLatestVersion.equals(usedVersion))
+			return UpdateCheckResult.RUNNING_LATEST_VERSION;
+		return UpdateCheckResult.NEW_VERSION_AVAILABLE;
+	}
+
+	/**
+	 * Checks for updates now and sends the result to the given list of
+	 * CommandSenders. Can be null to silently check for updates.
+	 *
+	 * @param requesters CommandSenders to send the result to, or null
+	 */
+	public void checkNow(@Nullable CommandSender... requesters) {
+		if (main == null) {
+			throw new IllegalStateException("Plugin has not been set.");
+		}
+		if (apiLink == null) {
+			throw new IllegalStateException("API Link has not been set.");
 		}
 
-		/**
-		 * @return the notifyPermission
-		 */
-		public String getNotifyPermission() {
-			return notifyPermission;
+		if (userAgentString == null) {
+			userAgentString = UserAgentBuilder.getDefaultUserAgent().build();
 		}
 
-		/**
-		 * @return the spigotUserId
-		 */
-		public String getSpigotUserId() {
-			return spigotUserId;
-		}
+		Bukkit.getScheduler().runTaskAsynchronously(main, () -> {
 
-		/**
-		 * @return the coloredConsoleOutput
-		 */
-		public boolean isColoredConsoleOutput() {
-			return coloredConsoleOutput;
-		}
+			UpdateCheckEvent updateCheckEvent;
 
-		/**
-		 * @return the notifyOpsOnJoin
-		 */
-		public boolean isNotifyOpsOnJoin() {
-			return notifyOpsOnJoin;
-		}
+			try {
+				final HttpURLConnection httpConnection = (HttpURLConnection) new URL(apiLink).openConnection();
+				httpConnection.addRequestProperty("User-Agent", userAgentString);
+				if (timeout > 0) {
+					httpConnection.setConnectTimeout(timeout);
+				}
+				final InputStreamReader input = new InputStreamReader(httpConnection.getInputStream());
+				final BufferedReader reader = new BufferedReader(input);
+				cachedLatestVersion = reader.readLine().trim();
+				reader.close();
+				updateCheckEvent = new UpdateCheckEvent(UpdateCheckSuccess.SUCCESS);
+			} catch(final Exception e) {
+				updateCheckEvent = new UpdateCheckEvent(UpdateCheckSuccess.FAIL);
+				Bukkit.getScheduler().runTask(main, () -> getOnUnsuccessfulCachedLatestVersion().accept(e));
+			}
 
-		/**
-		 * @return the notifyRequesters
-		 */
-		public boolean isNotifyRequesters() {
-			return notifyRequesters;
-		}
+			UpdateCheckEvent finalUpdateCheckEvent = updateCheckEvent.setRequesters(requesters);
+			Bukkit.getScheduler().runTask(main, () -> {
+				// MrNemo64 start
+				if (finalUpdateCheckEvent.getSuccess() == UpdateCheckSuccess.SUCCESS)
+					getOnSuccessfulCachedLatestVersion().accept(requesters, cachedLatestVersion);
+				// MrNemo64 end
+				Bukkit.getPluginManager().callEvent(finalUpdateCheckEvent);
+			});
+		});
+	}
 
-		/**
-		 * @return the usingPaidVersion
-		 */
-		public boolean isUsingPaidVersion() {
-			return usingPaidVersion;
+	/**
+	 * Checks that the class was properly relocated. Proudly stolen from bStats.org
+	 */
+	private void checkRelocation() {
+		final String defaultPackage = new String(new byte[] { 'd', 'e', '.', 'j', 'e', 'f', 'f', '_', 'm', 'e', 'd', 'i',
+				'a', '.', 'u', 'p', 'd', 'a', 't', 'e', 'c', 'h', 'e', 'c', 'k', 'e', 'r' });
+		final String examplePackage = new String(new byte[] { 'y', 'o', 'u', 'r', '.', 'p', 'a', 'c', 'k', 'a', 'g', 'e' });
+		if (this.getClass().getPackage().getName().startsWith(defaultPackage)
+				|| this.getClass().getPackage().getName().startsWith(examplePackage)) {
+			throw new IllegalStateException("UpdateChecker class has not been relocated correctly!");
 		}
-    
-    
-   // MrNemo64 end
-    
+	}
+
+	private boolean detectPaidVersion() {
+		return spigotUserId.matches("^[0-9]+$");
+	}
+
+	/**
+	 * Returns a list of applicable Download links.
+	 * <p>
+	 * If using the free version and there are links for the free and paid version,
+	 * element 0 will be the link to the paid version and element will be the link
+	 * to the free version
+	 * <p>
+	 * If using the paid version, there will be only one element containing the link
+	 * to the paid version, or, if that is not set, the link to the free version.
+	 * <p>
+	 * If there is no paid version, there will be only one element containing the
+	 * link to the free version, or, if that is not set, the link to the plus
+	 * version.
+	 * <p>
+	 * If no download links are set, returns an empty list.
+	 *
+	 * @return List of zero to two download links. If the list contains two links,
+	 *         the first element is the paid download link.
+	 */
+	public List<String> getAppropiateDownloadLinks() {
+		List<String> list = new ArrayList<>();
+
+		if (usingPaidVersion) {
+			if (paidDownloadLink != null) {
+				list.add(paidDownloadLink);
+			} else if (freeDownloadLink != null) {
+				list.add(freeDownloadLink);
+			}
+		} else {
+			if (paidDownloadLink != null) {
+				list.add(paidDownloadLink);
+			}
+			if (freeDownloadLink != null) {
+				list.add(freeDownloadLink);
+			}
+		}
+		return list;
+	}
+
+	/**
+	 * Returns the latest version string found by the UpdateChecker, or null if all
+	 * checks until yet have failed.
+	 *
+	 * @return
+	 */
+	public String getCachedLatestVersion() {
+		return cachedLatestVersion;
+	}
+
+	/**
+	 * Returns the changelog link
+	 *
+	 * @return
+	 */
+	public String getChangelogLink() {
+		return changelogLink;
+	}
+
+	/**
+	 * Sets a link to your plugin's changelog generated from your plugin's SpigotMC
+	 * Resource ID
+	 *
+	 * @param spigotResourceId
+	 * @return
+	 */
+	public UpdateChecker setChangelogLink(int spigotResourceId) {
+		return setChangelogLink(SPIGOT_DOWNLOAD_LINK + spigotResourceId + SPIGOT_CHANGELOG_SUFFIX);
+	}
+
+	/**
+	 * Sets a link to your plugin's changelog.
+	 *
+	 * @param link
+	 * @return
+	 */
+	public UpdateChecker setChangelogLink(@Nullable String link) {
+		changelogLink = link;
+		return this;
+	}
+
+	/**
+	 * Returns the donation link
+	 *
+	 * @return
+	 */
+	public String getDonationLink() {
+		return donationLink;
+	}
+
+	/**
+	 * Sets a link to your plugin's donation website
+	 *
+	 * @param donationLink
+	 * @return
+	 */
+	public UpdateChecker setDonationLink(@Nullable String donationLink) {
+		this.donationLink = donationLink;
+		return this;
+	}
+
+	protected Plugin getPlugin() {
+		return main;
+	}
+
+	/**
+	 * Gets the version string of the currently used plugin version.
+	 *
+	 * @return
+	 */
+	public String getUsedVersion() {
+		return usedVersion;
+	}
+
+	/**
+	 * Sets whether or not the used and latest version will be displayed in color in
+	 * the console
+	 *
+	 * @param coloredConsoleOutput
+	 * @return
+	 */
+	public UpdateChecker setColoredConsoleOutput(boolean coloredConsoleOutput) {
+		this.coloredConsoleOutput = coloredConsoleOutput;
+		return this;
+	}
+
+	/**
+	 * Sets the download link for your plugin generated from your plugin's SpigotMC
+	 * Resource ID. Use this if there is only one version of your plugin, either
+	 * only a free or only a paid version.
+	 *
+	 * @param spigotResourceId
+	 * @return
+	 */
+	public UpdateChecker setDownloadLink(int spigotResourceId) {
+		return setDownloadLink(SPIGOT_DOWNLOAD_LINK + spigotResourceId);
+	}
+
+	/**
+	 * Sets the download link for your plugin. Use this if there is only one version
+	 * of your plugin, either only a free or only a paid version.
+	 *
+	 * @param downloadLink
+	 * @return
+	 */
+	public UpdateChecker setDownloadLink(@Nullable String downloadLink) {
+		this.paidDownloadLink = null;
+		this.freeDownloadLink = downloadLink;
+		return this;
+	}
+
+	/**
+	 * Sets the download link for the free version of your plugin generated from
+	 * your plugin's SpigotMC Resource ID. Use this if there is both, a free and a
+	 * paid version of your plugin available.
+	 *
+	 * @param spigotResourceId
+	 * @return
+	 */
+	public UpdateChecker setFreeDownloadLink(int spigotResourceId) {
+		return setFreeDownloadLink(SPIGOT_DOWNLOAD_LINK + spigotResourceId);
+	}
+
+	/**
+	 * Sets the download link for the free version of your plugin. Use this if there
+	 * is both, a free and a paid version of your plugin available.
+	 *
+	 * @param freeDownloadLink
+	 * @return
+	 */
+	public UpdateChecker setFreeDownloadLink(@Nullable String freeDownloadLink) {
+		this.freeDownloadLink = freeDownloadLink;
+		return this;
+	}
+
+	/**
+	 * Sets the suffix for the free version's name. E.g. when you set this to
+	 * "Free", the Download link for the free version will be shown as "Download
+	 * (Free): [Link]"
+	 *
+	 * @param nameFreeVersion
+	 * @return
+	 */
+	public UpdateChecker setNameFreeVersion(String nameFreeVersion) {
+		this.nameFreeVersion = nameFreeVersion;
+		return this;
+	}
+
+	/**
+	 * Sets the suffix for the paid version's name. E.g. when you set this to
+	 * "Platinum version", the Download link for the paid version will be shown as
+	 * "Download (Platinum version): [Link]"
+	 *
+	 * @param namePaidVersion
+	 * @return
+	 */
+	public UpdateChecker setNamePaidVersion(String namePaidVersion) {
+		this.namePaidVersion = namePaidVersion;
+		return this;
+	}
+
+	/**
+	 * You can set a permission name. Players joining with this permission will be
+	 * informed when there is a new version available.
+	 *
+	 * @param permission
+	 * @return
+	 */
+	public UpdateChecker setNotifyByPermissionOnJoin(@Nullable String permission) {
+		notifyPermission = permission;
+		return this;
+	}
+
+	/**
+	 * Whether or not to inform OPs on join when there is a new version available.
+	 *
+	 * @param notifyOpsOnJoin
+	 * @return
+	 */
+	public UpdateChecker setNotifyOpsOnJoin(boolean notifyOpsOnJoin) {
+		this.notifyOpsOnJoin = notifyOpsOnJoin;
+		return this;
+	}
+
+	/**
+	 * Whether or not CommandSenders who request an update check will be notified of
+	 * the result.
+	 *
+	 * @param notify
+	 * @return
+	 */
+	public UpdateChecker setNotifyRequesters(boolean notify) {
+		notifyRequesters = notify;
+		return this;
+	}
+
+	/**
+	 * Sets the download link for the paid version of your plugin generated from
+	 * your plugin's SpigotMC Resource ID. Use this if there is both, a free and a
+	 * paid version of your plugin available.
+	 *
+	 * @param spigotResourceId
+	 * @return
+	 */
+	public UpdateChecker setPaidDownloadLink(int spigotResourceId) {
+		return setPaidDownloadLink(SPIGOT_DOWNLOAD_LINK + spigotResourceId);
+	}
+
+	/**
+	 * Sets the download link for the paid version of your plugin. Use this if there
+	 * is both, a free and a paid version of your plugin available.
+	 *
+	 * @param link
+	 * @return
+	 */
+	public UpdateChecker setPaidDownloadLink(@NotNull String link) {
+		paidDownloadLink = link;
+		return this;
+	}
+
+	/**
+	 * Sets the timeout for the HTTP(S) connection in milliseconds. 0 = use Java's
+	 * default value
+	 *
+	 * @param timeout
+	 */
+	public UpdateChecker setTimeout(int timeout) {
+		this.timeout = timeout;
+		return this;
+	}
+
+	/**
+	 * Sets the UserAgent string using a UserAgentBuilder
+	 *
+	 * @param userAgentBuilder
+	 * @return
+	 */
+	public UpdateChecker setUserAgent(@NotNull UserAgentBuilder userAgentBuilder) {
+		userAgentString = userAgentBuilder.build();
+		return this;
+	}
+
+	/**
+	 * Sets the UserAgent string using plain text
+	 *
+	 * @param userAgent
+	 * @return
+	 */
+	public UpdateChecker setUserAgent(@Nullable String userAgent) {
+		userAgentString = userAgent;
+		return this;
+	}
+
+	/**
+	 * Tells the UpdateChecker whether the server already uses the paid version of
+	 * your plugin. If yes, the downloads to the free version are not shown. You can
+	 * ignore this if you only offer one version of your plugin. When this value is
+	 * not set, the Update Checker automatically sets this to true by checking the
+	 * %%__USER__%% placeholder, see
+	 * https://www.spigotmc.org/wiki/premium-resource-placeholders-identifiers/
+	 *
+	 * @param paidVersion
+	 * @return
+	 */
+	public UpdateChecker setUsingPaidVersion(boolean paidVersion) {
+		usingPaidVersion = paidVersion;
+		return this;
+	}
+
+	/**
+	 * Stops the scheduled update checks - THIS IS NOT NEEDED when calling
+	 * checkEveryXHours(double) again, as the UpdateChecker will automatically stop
+	 * its previous task.
+	 */
+	public void stop() {
+		if (taskId != -1) {
+			Bukkit.getScheduler().cancelTask(taskId);
+		}
+		taskId = -1;
+	}
+
+	// MrNemo64 start
+	/**
+	 * @return True if the lastest version si being used, false otherwise
+	 */
+	public boolean isUsingLastestVersion() {
+		return usedVersion.equals(instance.cachedLatestVersion);
+	}
+
+	/**
+	 * @return the nameFreeVersion
+	 */
+	public String getNameFreeVersion() {
+		return nameFreeVersion;
+	}
+
+	/**
+	 * @return the namePaidVersion
+	 */
+	public String getNamePaidVersion() {
+		return namePaidVersion;
+	}
+
+	/**
+	 * @return the notifyPermission
+	 */
+	public String getNotifyPermission() {
+		return notifyPermission;
+	}
+
+	/**
+	 * @return the spigotUserId
+	 */
+	public String getSpigotUserId() {
+		return spigotUserId;
+	}
+
+	/**
+	 * @return the coloredConsoleOutput
+	 */
+	public boolean isColoredConsoleOutput() {
+		return coloredConsoleOutput;
+	}
+
+	/**
+	 * @return the notifyOpsOnJoin
+	 */
+	public boolean isNotifyOpsOnJoin() {
+		return notifyOpsOnJoin;
+	}
+
+	/**
+	 * @return the notifyRequesters
+	 */
+	public boolean isNotifyRequesters() {
+		return notifyRequesters;
+	}
+
+	/**
+	 * @return the usingPaidVersion
+	 */
+	public boolean isUsingPaidVersion() {
+		return usingPaidVersion;
+	}
+
+	/**
+	 * @return the onSuccessfulCachedLatestVersion
+	 */
+	public BiConsumer<CommandSender[], String> getOnSuccessfulCachedLatestVersion() {
+		return onSuccessfulCachedLatestVersion;
+	}
+
+	/**
+	 * @param onSuccessfulCachedLatestVersion the onSuccessfulCachedLatestVersion to
+	 *                                        set. If null setted to default. This
+	 *                                        consumer runs before the event and
+	 *                                        only runs if the check vas successful
+	 */
+	public UpdateChecker setOnSuccessfulCachedLatestVersion(
+			BiConsumer<CommandSender[], String> onSuccessfulCachedLatestVersion) {
+		this.onSuccessfulCachedLatestVersion = onSuccessfulCachedLatestVersion == null ? (requesters, cachedVersion) -> {}
+				: onSuccessfulCachedLatestVersion;
+		return this;
+	}
+
+	/**
+	 * @return the onUnsuccessfulCachedLatestVersion
+	 */
+	public Consumer<Exception> getOnUnsuccessfulCachedLatestVersion() {
+		return onUnsuccessfulCachedLatestVersion;
+	}
+
+	/**
+	 * @param onUnsuccessfulCachedLatestVersion If null setted to default. The
+	 *                                          recived parameter is the exception
+	 *                                          thrown in the version getting
+	 *                                          process
+	 */
+	public UpdateChecker setOnUnsuccessfulCachedLatestVersion(Consumer<Exception> onUnsuccessfulCachedLatestVersion) {
+		this.onUnsuccessfulCachedLatestVersion = onUnsuccessfulCachedLatestVersion == null ? (ex) -> ex.printStackTrace()
+				: onUnsuccessfulCachedLatestVersion;
+		return this;
+	}
+
+	// MrNemo64 end
+
 }

--- a/src/main/java/de/jeff_media/updatechecker/UserAgentBuilder.java
+++ b/src/main/java/de/jeff_media/updatechecker/UserAgentBuilder.java
@@ -1,10 +1,11 @@
 package de.jeff_media.updatechecker;
 
-import org.bukkit.Bukkit;
-import org.bukkit.plugin.Plugin;
-
 import java.util.ArrayList;
 import java.util.Iterator;
+import java.util.List;
+
+import org.bukkit.Bukkit;
+import org.bukkit.plugin.Plugin;
 
 /**
  * Creates a User-Agent string. Always starts with "JEFF-Media-GbR-SpigotUpdateChecker/[version]" followed by all added parameters.
@@ -13,7 +14,7 @@ public class UserAgentBuilder {
 
     private final StringBuilder builder = new StringBuilder("JEFF-Media-GbR-SpigotUpdateChecker/").append(UpdateChecker.VERSION);
     private final UpdateChecker instance = UpdateChecker.getInstance();
-    private final ArrayList<String> list = new ArrayList<>();
+    private final List<String> list = new ArrayList<>();
     private final Plugin plugin = instance.getPlugin();
 
     /**
@@ -84,7 +85,7 @@ public class UserAgentBuilder {
      * @return
      */
     public UserAgentBuilder addSpigotUserId() {
-        String uid = instance.usingPaidVersion ? instance.spigotUserId : "none";
+        String uid = instance.isUsingPaidVersion() ? instance.getSpigotUserId(): "none";
         list.add("SpigotUID/" + uid);
         return this;
     }
@@ -95,7 +96,7 @@ public class UserAgentBuilder {
      * @return
      */
     public UserAgentBuilder addUsingPaidVersion() {
-        list.add("Paid/" + instance.usingPaidVersion);
+        list.add("Paid/" + instance.isUsingPaidVersion());
         return this;
     }
 


### PR DESCRIPTION
Some parts of the code have been changed to follow java guidelines. Mainly using getters instead of directly accesing the fields of the UpdateChecker class.
The main focus of this pull request if to add a way to listen to version checks without having to register a new event listener and allowing the user to decide what to do in case of exception.
The last change is making the Messages#sendLinks(Player) accept a Player[] instead of Player. This way we can send the link message to several players without having to call the method every time and avoid creating the message every time