### PR TITLE
Add customisable message colors

### DIFF
--- a/src/main/java/com/jeff_media/updatechecker/MessageColor.java
+++ b/src/main/java/com/jeff_media/updatechecker/MessageColor.java
@@ -1,0 +1,77 @@
+package com.jeff_media.updatechecker;
+
+import java.util.Objects;
+import org.bukkit.ChatColor;
+import org.jetbrains.annotations.NotNull;
+
+/**
+ * This enum stores a list of colors used for the update checker's messages.
+ */
+public enum MessageColor {
+
+    SEVERE(ChatColor.RED),
+    HIGHLIGHT(ChatColor.GOLD),
+    NOTE(ChatColor.DARK_GRAY),
+    STANDARD(ChatColor.GRAY),
+    SUCCESS(ChatColor.GREEN),
+    VERSION_NEWER(ChatColor.GREEN),
+    VERSION_OLDER(ChatColor.RED);
+
+    private final ChatColor defaultColor;
+    private ChatColor color;
+
+    /**
+     * Declare a new message color type
+     *
+     * @param defaultColor color to be used by default
+     */
+    MessageColor(final @NotNull ChatColor defaultColor) {
+        Objects.requireNonNull(defaultColor, "defaultColor");
+
+        this.defaultColor = defaultColor;
+        this.color = defaultColor;
+    }
+
+    /**
+     * Used to more concisely concatenate message colors
+     *
+     * @return color, in string form
+     */
+    @Override
+    @NotNull
+    public String toString() {
+        return getColor().toString();
+    }
+
+    /**
+     * Get the default color used for this message type
+     *
+     * @return default color
+     */
+    @SuppressWarnings("unused")
+    @NotNull
+    public ChatColor getDefaultColor() {
+        return defaultColor;
+    }
+
+    /**
+     * Get the color used for this message type
+     *
+     * @return color
+     */
+    @NotNull
+    public ChatColor getColor() {
+        return color;
+    }
+
+    /**
+     * Change the color for this message type
+     *
+     * @param color color to use
+     */
+    @SuppressWarnings("unused")
+    public void setColor(final @NotNull ChatColor color) {
+        this.color = Objects.requireNonNull(color, "color");
+    }
+
+}

--- a/src/main/java/com/jeff_media/updatechecker/UpdateCheckerMessages.java
+++ b/src/main/java/com/jeff_media/updatechecker/UpdateCheckerMessages.java
@@ -22,7 +22,6 @@ import net.md_5.bungee.api.chat.ClickEvent;
 import net.md_5.bungee.api.chat.ComponentBuilder;
 import net.md_5.bungee.api.chat.HoverEvent;
 import net.md_5.bungee.api.chat.TextComponent;
-import org.bukkit.ChatColor;
 import org.bukkit.entity.Player;
 import org.bukkit.plugin.Plugin;
 import org.jetbrains.annotations.NotNull;
@@ -72,8 +71,10 @@ class UpdateCheckerMessages {
 
         lines.add(String.format("There is a new version of %s available!", plugin.getName()));
         lines.add(" ");
-        lines.add(String.format("Your version:   %s%s", instance.isColoredConsoleOutput() ? ChatColor.RED : "", event.getUsedVersion()));
-        lines.add(String.format("Latest version: %s%s", instance.isColoredConsoleOutput() ? ChatColor.GREEN : "", event.getLatestVersion()));
+        lines.add(String.format("Your version:   %s%s", instance.isColoredConsoleOutput() ? MessageColor.VERSION_OLDER
+            : "", event.getUsedVersion()));
+        lines.add(String.format("Latest version: %s%s", instance.isColoredConsoleOutput() ? MessageColor.VERSION_NEWER
+            : "", event.getLatestVersion()));
 
         List<String> downloadLinks = instance.getAppropriateDownloadLinks();
 
@@ -99,15 +100,17 @@ class UpdateCheckerMessages {
     protected static void printCheckResultToPlayer(Player player, boolean showMessageWhenLatestVersion) {
         UpdateChecker instance = UpdateChecker.getInstance();
         if (instance.getLastCheckResult() == UpdateCheckResult.NEW_VERSION_AVAILABLE) {
-            player.sendMessage(ChatColor.GRAY + "There is a new version of " + ChatColor.GOLD + instance.getPlugin().getName() + ChatColor.GRAY + " available.");
+            player.sendMessage(MessageColor.STANDARD + "There is a new version of " + MessageColor.HIGHLIGHT + instance.getPlugin().getName() + MessageColor.STANDARD + " available.");
             sendLinks(player);
-            player.sendMessage(ChatColor.DARK_GRAY + "Latest version: " + ChatColor.GREEN + instance.getLatestVersion() + ChatColor.DARK_GRAY + " | Your version: " + ChatColor.RED + instance.getUsedVersion());
+            player.sendMessage(MessageColor.NOTE + "Latest version: " + MessageColor.VERSION_NEWER + instance.getLatestVersion() + MessageColor.NOTE + " | Your version: " + MessageColor.VERSION_OLDER
+                + instance.getUsedVersion());
             player.sendMessage("");
         } else if (instance.getLastCheckResult() == UpdateCheckResult.UNKNOWN) {
-            player.sendMessage(ChatColor.GOLD + instance.getPlugin().getName() + ChatColor.RED + " could not check for updates.");
+            player.sendMessage(MessageColor.HIGHLIGHT + instance.getPlugin().getName() + MessageColor.SEVERE
+                + " could not check for updates.");
         } else {
             if (showMessageWhenLatestVersion) {
-                player.sendMessage(ChatColor.GREEN + "You are running the latest version of " + ChatColor.GOLD + instance.getPlugin().getName());
+                player.sendMessage(MessageColor.SUCCESS + "You are running the latest version of " + MessageColor.HIGHLIGHT + instance.getPlugin().getName());
             }
         }
     }


### PR DESCRIPTION
This PR is only useful as a temporary aid to customising messages. This PR is likely to be rejected since it isn't a permanent solution, I am just submitting this in case you prefer it.

This PR allows the customisation of message colors, however, this PR does not allow customisation of the content of the messages.

This is likely incompatible with #9 and does not fully solve #20.

