### PR TITLE
Added hex colour support and configurable messages

### DIFF
--- a/src/main/java/com/jeff_media/updatechecker/UpdateChecker.java
+++ b/src/main/java/com/jeff_media/updatechecker/UpdateChecker.java
@@ -888,4 +888,102 @@ public class UpdateChecker {
         return this;
     }
 
+    /**
+     * Sets the Button Format string using plain text
+     *
+     * @param format message format string
+     * @return UpdateChecker instance being ran
+     */
+    public UpdateChecker setButtonFormat(@NotNull String format) {
+        UpdateCheckerMessages.setButtonFormat(format);
+        return this;
+    }
+
+    /**
+     * Sets the Button Link Format string using plain text
+     *
+     * @param format message format string
+     * @return UpdateChecker instance being ran
+     */
+    public UpdateChecker setButtonLinkFormat(@NotNull String format) {
+        UpdateCheckerMessages.setButtonLinkFormat(format);
+        return this;
+    }
+
+    /**
+     * Sets the Console's "using latest" message string using plain text
+     *
+     * @param message message format string
+     * @return UpdateChecker instance being ran
+     */
+    public UpdateChecker setConsoleUsingLatestMsg(@NotNull String message) {
+        UpdateCheckerMessages.setConsoleUsingLatestMsg(message);
+        return this;
+    }
+
+    /**
+     * Sets the Console's "new version" message string using plain text
+     *
+     * @param message message format string
+     * @return UpdateChecker instance being ran
+     */
+    public UpdateChecker setConsoleNewVersionMsg(@NotNull String message) {
+        UpdateCheckerMessages.setConsoleNewVersionMsg(message);
+        return this;
+    }
+
+    /**
+     * Sets whether the fancy console border is added
+     *
+     * @param border whether the border is enabled
+     * @return UpdateChecker instance being ran
+     */
+    public UpdateChecker setConsoleBorder(boolean border) {
+        UpdateCheckerMessages.setConsoleBorder(border);
+        return this;
+    }
+
+    /**
+     * Sets the ingame "using latest" message string using plain text
+     *
+     * @param message message format string
+     * @return UpdateChecker instance being ran
+     */
+    public UpdateChecker setIngameUsingLatestMsg(@NotNull String message) {
+        UpdateCheckerMessages.setIngameUsingLatestMsg(message);
+        return this;
+    }
+
+    /**
+     * Sets the ingame "using latest" message string using plain text
+     *
+     * @param message message format string
+     * @return UpdateChecker instance being ran
+     */
+    public UpdateChecker setIngameNewVersionMsg(@NotNull String message) {
+        UpdateCheckerMessages.setIngameNewVersionMsg(message);
+        return this;
+    }
+
+    /**
+     * Sets the ingame "version changes" message string using plain text
+     *
+     * @param message message format string
+     * @return UpdateChecker instance being ran
+     */
+    public UpdateChecker setIngameVersionChangesMsg(@NotNull String message) {
+        UpdateCheckerMessages.setIngameVersionChangesMsg(message);
+        return this;
+    }
+
+    /**
+     * Sets the ingame "couldn't check for updates" message string using plain text
+     *
+     * @param message message format string
+     * @return UpdateChecker instance being ran
+     */
+    public UpdateChecker setCouldNotCheckForUpdatesMsg(@NotNull String message) {
+        UpdateCheckerMessages.setCouldNotCheckForUpdatesMsg(message);
+        return this;
+    }
 }

--- a/src/main/java/com/jeff_media/updatechecker/UpdateCheckerMessages.java
+++ b/src/main/java/com/jeff_media/updatechecker/UpdateCheckerMessages.java
@@ -142,8 +142,8 @@ class UpdateCheckerMessages {
         List<String> downloadLinks = instance.getAppropriateDownloadLinks();
 
         if (downloadLinks.size() == 2) {
-            links.add(createLink(String.format("Download (%s)", instance.getNamePaidVersion()), downloadLinks.get(0)));
-            links.add(createLink(String.format("Download (%s)", instance.getNameFreeVersion()), downloadLinks.get(1)));
+            links.add(createLink(parsePlaceholders("Download (%resource-paid-name%)", instance), downloadLinks.get(0)));
+            links.add(createLink(parsePlaceholders("Download (%resource-name%)", instance), downloadLinks.get(1)));
         } else if (downloadLinks.size() == 1) {
             links.add(createLink("Download", downloadLinks.get(0)));
         }
@@ -157,8 +157,7 @@ class UpdateCheckerMessages {
             links.add(createLink("Support", instance.getSupportLink()));
         }
 
-        final TextComponent placeholder = new TextComponent(" | ");
-        placeholder.setColor(net.md_5.bungee.api.ChatColor.GRAY);
+        final TextComponent placeholder = new TextComponent(translateHexColorCodes(" &7| "));
 
         TextComponent text = new TextComponent("");
 


### PR DESCRIPTION
I have no clue how much of this works as I am not sure quite of how to use the maven setup like you have. But this should definitely put you on the right tracks to being able to make all messages configurable.

I replaced String.format with a parsePlaceholder, option which allows for placeholders to be put wherever the user pleases

I also added an option to toggle the fancy border you made as it wouldn't necessarily work for everyone when they configured