### PR TITLE
Fix not using Strings for id

### DIFF
--- a/README.md
+++ b/README.md
@@ -120,7 +120,7 @@ To get a working UpdateChecker, this is already enough:
 ```java
 public class MyPlugin extends JavaPlugin {
     // To get the Resource ID, look at the number at the end of the URL of your plugin's SpigotMC page
-    private static final int SPIGOT_RESOURCE_ID = 59773;
+    private static final String SPIGOT_RESOURCE_ID = "59773";
 
     @Override
     public void onEnable() {
@@ -140,7 +140,7 @@ Of course, there are many more options you can use. For example:
 import com.jeff_media.updatechecker.UpdateCheckSource;
 
 public class MyPlugin extends JavaPlugin {
-    private static final int SPIGOT_RESOURCE_ID = 59773;
+    private static final String SPIGOT_RESOURCE_ID = "59773";
 
     @Override
     public void onEnable() {


### PR DESCRIPTION
It seems that you used to use an `int` parameter when initializing an `UpdateChecker`, but not anymore. The README.md still uses an `int` in the example. This PR just switches those to Strings.

For example, in this deprecated method, you call `String.valueOf(int)` so you can call the method; passing the int does not work.
https://github.com/mfnalex/Spigot-UpdateChecker/blob/master/src/main/java/com/jeff_media/updatechecker/UpdateChecker.java#L226

 I also made sure to check the other methods to ensure they had ints:
 1. https://github.com/mfnalex/Spigot-UpdateChecker/blob/master/src/main/java/com/jeff_media/updatechecker/UpdateChecker.java#L815
 2. https://github.com/mfnalex/Spigot-UpdateChecker/blob/master/src/main/java/com/jeff_media/updatechecker/UpdateChecker.java#L854
 
 Thanks,
 CJCrafter